### PR TITLE
Nil check in compare

### DIFF
--- a/lib/sem_version.rb
+++ b/lib/sem_version.rb
@@ -53,6 +53,8 @@ class SemVersion
   end
 
   def <=>(other)
+    return nil if other.nil?
+    
     maj = @major <=> other.major
     return maj unless maj == 0
 


### PR DESCRIPTION
This allows checking for nil with a SemVersion

The following did not work previously, but works now:
```ruby
# Imagine there is a statement here that could make version nil
version = SemVersion.new("1.1.1")

if version.nil?
  puts "it's nil"
else
  # Do something with the version
end
```